### PR TITLE
[STREAM] add caw layer subscribe

### DIFF
--- a/src/caw.h
+++ b/src/caw.h
@@ -17,6 +17,9 @@ namespace cawfunc {
 // Return true if register success, false if failed.
 bool RegisterUser(const caw::RegisteruserRequest &request, KVStoreClient &client);
 
+// Resolve hashtags from caw text
+std::vector<std::string> ResolveHashtags(const std::string &text);
+
 // Create a new caw and return caw_id.
 caw::Caw Caw(const caw::CawRequest &request, KVStoreClient &client);
 
@@ -28,6 +31,10 @@ caw::ReadReply Read(const caw::ReadRequest &request, KVStoreClient &client);
 
 // Return user's following and followers.
 caw::ProfileReply Profile(const caw::ProfileRequest & request, KVStoreClient &client);
+
+// Return caws that have hashtag
+caw::SubscribeReply Subscribe(const caw::SubscribeRequest &request,
+                                            KVStoreClient &client);
 
 bool UserExists(const std::string &username, KVStoreClient &client);
 

--- a/src/prefix.h
+++ b/src/prefix.h
@@ -20,6 +20,8 @@ namespace prefix {
   const std::string kCawUSeconds = std::string("cawuseconds_"); // (cawuseconds_ + caw_id) -- timestamp useconds
 
   const std::string kEventType = std::string("event_"); // (event_ + event_id) -- functions
+  // prefix for Stream 
+  const std::string kStream_tag2caws = std::string("stream_tag2caws_"); // (stream_tag2caws_hashtag) -- set of serilized caws that contains hashtag
 } // namespace prefix
 
 #endif

--- a/src/proto/caw.proto
+++ b/src/proto/caw.proto
@@ -53,6 +53,15 @@ message ReadReply {
   repeated Caw caws = 1;  // The requested caw thread.
 }
 
+message SubscribeRequest {
+  string username = 1;  // The username of user who would like to subscribe hashtag
+  string hashtag = 2;  // The hashtag uesr subscribe to
+}
+
+message SubscribeReply {
+  repeated Caw caws = 1; // The caws that contains hashtag
+}
+
 message ProfileRequest {
   string username = 1;
 }


### PR DESCRIPTION
Hi Hao,

This PR add the stream function in caw layer.
- Main modification:
   - Subscribe() in caw layer will ask our kvstore layer for all caws that contains hashtags and return to upper layer.
   - Caw() in caw layer will check hashtags in the new published caw, resolve all hashtags it has, and put a kv pair for each hashtag into our kvstore layer(k: prefix::kStream_tag2caw_ourhashtag, v:serielized_caw)
   - Unittest for modified Caw() and ResolveHashtags() functions

please let me know if there is any confusion.