### PR TITLE
[STREAM] add detail in cmd layer

### DIFF
--- a/src/cmd_client.cc
+++ b/src/cmd_client.cc
@@ -198,11 +198,6 @@ void CMDClient::Subscribe(const std::string &username, const std::string &hashta
 	  return;
   }
 
-  // Timestamp for subscription, used to filter out old caws
-  std::chrono::seconds secs_subscription = std::chrono::duration_cast<std::chrono::seconds>(
-    std::chrono::system_clock::now().time_since_epoch()
-  );
-
   std::cout << username << " is subscribing " << hashtag << std::endl;
   // Construct caw::SubscribeRequest
   caw::SubscribeRequest req;
@@ -213,16 +208,16 @@ void CMDClient::Subscribe(const std::string &username, const std::string &hashta
   int event_type = IsRegistered("subscribe");
   event_req.set_event_type(event_type);
   (event_req.mutable_payload())->PackFrom(req);
-  // request for new caws
-  faz::EventReply event_rep = fazclient_.Event(event_req);
-  caw::SubscribeReply rep;
-  event_rep.payload().UnpackTo(&rep);
 
-  // Printout results
+  // Request and Printout results
   std::cout << "[" << hashtag << "]" << std::endl;
   // request for new caws every 200 ms
   int interval = 200;
   while (true) {    
+    // Timestamp for subscribe request, used to filter out old caws
+    std::chrono::seconds secs_subscription = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now().time_since_epoch()
+    );
     faz::EventReply event_rep = fazclient_.Event(event_req);
     caw::SubscribeReply rep;
     event_rep.payload().UnpackTo(&rep);  

--- a/src/cmd_client.cc
+++ b/src/cmd_client.cc
@@ -211,8 +211,8 @@ void CMDClient::Subscribe(const std::string &username, const std::string &hashta
 
   // Request and Printout results
   std::cout << "[" << hashtag << "]" << std::endl;
-  // request for new caws every 200 ms
-  int interval = 200;
+  // request for new caws every 1s
+  int interval = 1000;
   while (true) {    
     // Timestamp for subscribe request, used to filter out old caws
     std::chrono::seconds secs_subscription = std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/cmd_client.cc
+++ b/src/cmd_client.cc
@@ -197,7 +197,48 @@ void CMDClient::Subscribe(const std::string &username, const std::string &hashta
 	  std::cout << "Log in before subscribe" << std::endl;
 	  return;
   }
+
+  // Timestamp for subscription, used to filter out old caws
+  std::chrono::seconds secs_subscription = std::chrono::duration_cast<std::chrono::seconds>(
+    std::chrono::system_clock::now().time_since_epoch()
+  );
+
   std::cout << username << " is subscribing " << hashtag << std::endl;
+  // Construct caw::SubscribeRequest
+  caw::SubscribeRequest req;
+  req.set_username(username);
+  req.set_hashtag(hashtag);
+  // Pack to faz::EventRequest
+  faz::EventRequest event_req;
+  int event_type = IsRegistered("subscribe");
+  event_req.set_event_type(event_type);
+  (event_req.mutable_payload())->PackFrom(req);
+  // request for new caws
+  faz::EventReply event_rep = fazclient_.Event(event_req);
+  caw::SubscribeReply rep;
+  event_rep.payload().UnpackTo(&rep);
+
+  // Printout results
+  std::cout << "[" << hashtag << "]" << std::endl;
+  // request for new caws every 200 ms
+  int interval = 200;
+  while (true) {    
+    faz::EventReply event_rep = fazclient_.Event(event_req);
+    caw::SubscribeReply rep;
+    event_rep.payload().UnpackTo(&rep);  
+    for (int i = 0; i < rep.caws_size(); i++) {
+      caw::Caw cur_caw = rep.caws(i);
+      if (cur_caw.timestamp().seconds() < secs_subscription.count()) {
+        // older caws
+        continue;
+      }
+      std::cout << "{"<< hashtag << "}" << 
+            "[" << cur_caw.id() << "] " << 
+            cur_caw.username() << " : " << 
+            cur_caw.text() << std::endl;
+    }
+  usleep(interval * 1000);
+  }
 }
 
 void PrintProfile(const std::string &username, const caw::ProfileReply &rep) {

--- a/src/cmd_client.h
+++ b/src/cmd_client.h
@@ -3,6 +3,9 @@
 
 #include <string>
 #include <unordered_map>
+#include <unistd.h>
+#include <chrono>
+#include <cstdlib>
 
 #include <gflags/gflags.h>
 #include <grpcpp/channel.h>


### PR DESCRIPTION
Hi Hao,

This PR finish the cmd part skeleton function. Subscribe() function is designed to be asynchronously update the streamed hashtag by requesting every second.

- Main modification
  - Request for caws contains corresponding hashtag every second.
  - Compared the timestamp of the subscribe request and the caw timestamp to filter out duplicate caws

- Test
   Will need to test out before merge after last PR with completed caw function merged

Please let me know if theres any confusion.