### PR TITLE
[STREAM-V2] cleanning up caw part because changing design to sync streaming way

### DIFF
--- a/src/caw.h
+++ b/src/caw.h
@@ -32,10 +32,6 @@ caw::ReadReply Read(const caw::ReadRequest &request, KVStoreClient &client);
 // Return user's following and followers.
 caw::ProfileReply Profile(const caw::ProfileRequest & request, KVStoreClient &client);
 
-// Return caws that have hashtag
-caw::SubscribeReply Subscribe(const caw::SubscribeRequest &request,
-                                            KVStoreClient &client);
-
 bool UserExists(const std::string &username, KVStoreClient &client);
 
 // Assign caw_id as current count of caws.
@@ -60,7 +56,6 @@ faz::EventReply CawHelper(const faz::EventRequest *event_req, KVStoreClient &cli
 faz::EventReply FollowHelper(const faz::EventRequest *event_req, KVStoreClient &client);
 faz::EventReply ReadHelper(const faz::EventRequest *event_req, KVStoreClient &client);
 faz::EventReply ProfileHelper(const faz::EventRequest *event_req, KVStoreClient &client);
-
 } // namespace cawfunc
 
 #endif

--- a/src/caw_test.cc
+++ b/src/caw_test.cc
@@ -49,24 +49,6 @@ TEST(CawfuncTest, CawTest) {
   ASSERT_EQ("0", result.parent_id());
 }
 
-// Test Caw with hastags text
-TEST(CawfuncTest, CawAndSubscribeWithHashtagTest) {
-  KVStoreClient client(grpc::CreateChannel("0.0.0.0:50001",
-                       grpc::InsecureChannelCredentials()));
-  caw::CawRequest caw_request;
-  caw_request.set_username("user1");
-  caw_request.set_text("Test caw with #hashtag1 and #hashtag2");
-  // not a reply to other caw.
-  caw_request.set_parent_id("");
-  caw::Caw result = cawfunc::Caw(caw_request, client);
-  // Check DB stream_tag2caw_hashtag1
-  std::vector<std::string> keyarr, valarr;
-  keyarr.push_back(prefix::kStream_tag2caws + "hashtag1");
-  keyarr.push_back(prefix::kStream_tag2caws + "hashtag2");
-  client.Get(keyarr, valarr);
-  ASSERT_EQ(2, valarr.size());
-}
-
 // Test cawfunc::Follow and caw::Profile works.
 TEST(CawfuncTest, FollowProfileTest) {
   KVStoreClient client(grpc::CreateChannel("0.0.0.0:50001",
@@ -116,15 +98,6 @@ TEST(CawfuncTest, ReadTest) {
     caw::Caw cur_caw = reply.caws(i);
     ASSERT_EQ(std::to_string(i), cur_caw.id());
   }
-}
-
-// Test function that resolve hashtags from caw text
-TEST(CawfuncTest, ResolveHashtagsTest) {
-  std::string caw_text = "This is a #test #msg";
-  std::vector<std::string> hashtags = cawfunc::ResolveHashtags(caw_text);
-  ASSERT_EQ(2, hashtags.size());
-  ASSERT_EQ("test", hashtags[0]);
-  ASSERT_EQ("msg", hashtags[1]);
 }
 
 } // namespace

--- a/src/prefix.h
+++ b/src/prefix.h
@@ -20,8 +20,6 @@ namespace prefix {
   const std::string kCawUSeconds = std::string("cawuseconds_"); // (cawuseconds_ + caw_id) -- timestamp useconds
 
   const std::string kEventType = std::string("event_"); // (event_ + event_id) -- functions
-  // prefix for Stream 
-  const std::string kStream_tag2caws = std::string("stream_tag2caws_"); // (stream_tag2caws_hashtag) -- set of serilized caws that contains hashtag
 } // namespace prefix
 
 #endif


### PR DESCRIPTION
Hi Hao,

  I found my previous design has some problems to filter out outdated caws and seems inefficient. So I'm switching gear to synchronically stream design. 
  
  My design is using server-side streaming service in Faz layer so that FazServer could continually stream new caw that contains corresponding hashtag back to FazClient. FazServer maintains a map of k-[hashtag] and v-[grpc::ServerWriter], the grpc::ServerWriter will write to stream when new caws was detected to have k-[hashtag].

  Since this design will not touch Caw layer, I cleaned up the caw layer from previous design in this PR.

Please let me know if there is any unclear.